### PR TITLE
feat(styles): discover external styles from marp-cli themeSet config

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ Use `-t` / `--theme` and `-s` / `--style` args to set the server-wide default. C
 
 Omitting these flags defaults to `default` theme and `default` style.
 
+### External styles via marp-cli config
+
+If a marp-cli configuration file (`.marprc.{yml,yaml,json,js,cjs,mjs}`, `marp.config.{js,cjs,mjs}`, or a `marp` field in `package.json`) is found anywhere up the directory tree at server start, every CSS file listed under its `themeSet` field is registered as an MCP style. The style name is read from the file's `/* @theme NAME */` directive (lowercased). External entries reuse the active theme's layouts, so all existing tools work unchanged.
+
+```yaml
+# .marprc.yml
+themeSet:
+  - ./themes/sample.css
+```
+
+```css
+/* themes/sample.css */
+/* @theme sample */
+section { background: #fff; }
+```
+
+`sample` is then a valid value for `-s` and shows up in `list_themes_and_styles` with `"external": true` and the absolute CSS path under `source`. Built-in style names are protected; any external collision is logged and skipped.
+
 ## 🛠️ Tools
 
 | Tool | Description |

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.19.1",
     "commander": "^14.0.3",
+    "cosmiconfig": "^9.0.1",
     "gray-matter": "^4.0.3",
     "image-size": "^2.0.2",
     "zod": "^3.25.76"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       commander:
         specifier: ^14.0.3
         version: 14.0.3
+      cosmiconfig:
+        specifier: ^9.0.1
+        version: 9.0.1(typescript@5.9.3)
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3

--- a/src/__tests__/readme-generator.test.ts
+++ b/src/__tests__/readme-generator.test.ts
@@ -135,6 +135,24 @@ Use \`-t\` / \`--theme\` and \`-s\` / \`--style\` args to set the server-wide de
 
 Omitting these flags defaults to \`default\` theme and \`default\` style.
 
+### External styles via marp-cli config
+
+If a marp-cli configuration file (\`.marprc.{yml,yaml,json,js,cjs,mjs}\`, \`marp.config.{js,cjs,mjs}\`, or a \`marp\` field in \`package.json\`) is found anywhere up the directory tree at server start, every CSS file listed under its \`themeSet\` field is registered as an MCP style. The style name is read from the file's \`/* @theme NAME */\` directive (lowercased). External entries reuse the active theme's layouts, so all existing tools work unchanged.
+
+\`\`\`yaml
+# .marprc.yml
+themeSet:
+  - ./themes/sample.css
+\`\`\`
+
+\`\`\`css
+/* themes/sample.css */
+/* @theme sample */
+section { background: #fff; }
+\`\`\`
+
+\`sample\` is then a valid value for \`-s\` and shows up in \`list_themes_and_styles\` with \`"external": true\` and the absolute CSS path under \`source\`. Built-in style names are protected; any external collision is logged and skipped.
+
 ## 🛠️ Tools
 
 | Tool | Description |

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
   setActiveStyle,
 } from "./styles/index.js";
 import { error as logError } from "./utils/logger.js";
+import { discoverExternalStyles } from "./utils/external-styles.js";
 import { startMcpServer } from "./mcp.js";
 import { registerCommands } from "./cli/commands.js";
 
@@ -87,6 +88,11 @@ program
 
 // Register CLI subcommands
 registerCommands(program);
+
+// Discover external styles (marp-cli `themeSet` via cosmiconfig) before
+// commander parses, so external names are valid arguments for `-s <name>`
+// and appear in the registry surfaced to MCP tools.
+await discoverExternalStyles();
 
 program.parseAsync().catch((err) => {
   logError("Fatal error", {

--- a/src/styles/__tests__/example-generator.test.ts
+++ b/src/styles/__tests__/example-generator.test.ts
@@ -396,7 +396,7 @@ function addSectionIconInline(slideContent: string, n: number): string {
 }
 
 function buildExampleMarkdown(
-  styleName: StyleName,
+  styleName: string,
   layouts: Record<string, { template: (params: Record<string, unknown>) => string }>,
   layoutNames: string[],
 ): string {

--- a/src/styles/__tests__/external-style.test.ts
+++ b/src/styles/__tests__/external-style.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import {
+  clearExternalStyles,
+  getAvailableStyleNames,
+  getExternalStyles,
+  getStyle,
+  registerExternalStyle,
+  setActiveStyle,
+  getActiveStyle,
+} from "../index.js";
+import type { StyleDefinition } from "../../themes/types.js";
+
+function makeDef(name: string, css = "/* css */"): StyleDefinition {
+  return {
+    name,
+    description: `External style discovered from /tmp/${name}.css`,
+    compatibleThemes: [],
+    css,
+    layouts: {},
+  };
+}
+
+describe("registerExternalStyle", () => {
+  beforeEach(() => {
+    clearExternalStyles();
+    setActiveStyle("default");
+  });
+
+  it("registers an external style and makes it discoverable", () => {
+    const ok = registerExternalStyle(makeDef("alpha"), "/tmp/alpha.css");
+    expect(ok).toBe(true);
+
+    expect(getStyle("alpha")?.name).toBe("alpha");
+    expect(getAvailableStyleNames()).toContain("alpha");
+    expect(getExternalStyles()).toHaveLength(1);
+  });
+
+  it("allows the external style to be activated", () => {
+    registerExternalStyle(makeDef("alpha", "section { color: red; }"), "/tmp/alpha.css");
+    setActiveStyle("alpha");
+    expect(getActiveStyle().name).toBe("alpha");
+    expect(getActiveStyle().css).toBe("section { color: red; }");
+  });
+
+  it("rejects collisions with built-in style names", () => {
+    const ok = registerExternalStyle(makeDef("default"), "/tmp/default.css");
+    expect(ok).toBe(false);
+    expect(getStyle("default")?.css).toBe("");
+    expect(getExternalStyles()).toHaveLength(0);
+  });
+
+  it("replaces a previously registered external when the same name registers again", () => {
+    registerExternalStyle(makeDef("alpha", "first"), "/tmp/a.css");
+    const ok = registerExternalStyle(makeDef("alpha", "second"), "/tmp/b.css");
+
+    expect(ok).toBe(true);
+    expect(getExternalStyles()).toHaveLength(1);
+    expect(getStyle("alpha")?.css).toBe("second");
+    expect(getExternalStyles()[0].source).toBe("/tmp/b.css");
+  });
+
+  it("throws when activating an unknown style name", () => {
+    expect(() => setActiveStyle("nonexistent")).toThrow(/Unknown style/);
+  });
+});

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -5,9 +5,10 @@ import { darkStyle } from "./dark/index.js";
 import { corporateStyle } from "./corporate/index.js";
 import { academicStyle } from "./academic/index.js";
 import { techStyle } from "./tech/index.js";
+import { warn } from "../utils/logger.js";
 import type { StyleDefinition, StyleName } from "../themes/types.js";
 
-const styles = {
+const builtinStyles: Record<StyleName, StyleDefinition> = {
   default: defaultStyle,
   rich: richStyle,
   minimal: minimalStyle,
@@ -15,7 +16,14 @@ const styles = {
   corporate: corporateStyle,
   academic: academicStyle,
   tech: techStyle,
-} satisfies Record<StyleName, StyleDefinition>;
+};
+
+interface ExternalStyleEntry {
+  def: StyleDefinition;
+  source: string;
+}
+
+const externalStyles = new Map<string, ExternalStyleEntry>();
 
 let activeStyle: StyleDefinition = defaultStyle;
 
@@ -23,16 +31,57 @@ export function getActiveStyle(): StyleDefinition {
   return activeStyle;
 }
 
-export function setActiveStyle(styleName: StyleName): void {
-  activeStyle = styles[styleName];
+export function setActiveStyle(styleName: string): void {
+  const style = getStyle(styleName);
+  if (!style) {
+    throw new Error(`Unknown style "${styleName}"`);
+  }
+  activeStyle = style;
 }
 
 export function getStyle(styleName: string): StyleDefinition | undefined {
-  return styles[styleName as StyleName];
+  const external = externalStyles.get(styleName);
+  if (external) return external.def;
+  return builtinStyles[styleName as StyleName];
 }
 
-export function getAvailableStyleNames(): StyleName[] {
-  return Object.keys(styles) as StyleName[];
+export function getAvailableStyleNames(): string[] {
+  return [...Object.keys(builtinStyles), ...externalStyles.keys()];
 }
 
-export { styles };
+/**
+ * Register a style discovered outside the built-in registry (e.g. via the
+ * marp-cli `themeSet` configuration). Collisions with built-in names are
+ * rejected; collisions between externals replace the previous entry.
+ */
+export function registerExternalStyle(
+  def: StyleDefinition,
+  source: string
+): boolean {
+  if (Object.prototype.hasOwnProperty.call(builtinStyles, def.name)) {
+    warn(
+      `External style "${def.name}" collides with a built-in style; skipping.`,
+      { source }
+    );
+    return false;
+  }
+  if (externalStyles.has(def.name)) {
+    warn(
+      `External style "${def.name}" already registered; replacing previous entry.`,
+      { previousSource: externalStyles.get(def.name)?.source, source }
+    );
+  }
+  externalStyles.set(def.name, { def, source });
+  return true;
+}
+
+export function getExternalStyles(): ExternalStyleEntry[] {
+  return Array.from(externalStyles.values());
+}
+
+/** Test-only: clear all externally registered styles. */
+export function clearExternalStyles(): void {
+  externalStyles.clear();
+}
+
+export { builtinStyles as styles };

--- a/src/themes/types.ts
+++ b/src/themes/types.ts
@@ -23,10 +23,14 @@ export interface ThemeDefinition {
   layouts: Record<string, SlideLayout>;
 }
 
+// Built-in style names. The runtime registry also accepts externally
+// registered names discovered from marp-cli config (`themeSet`); those
+// names cannot be enumerated statically, so `StyleDefinition.name` is
+// widened to `string` and lookup APIs accept any string.
 export type StyleName = "default" | "rich" | "minimal" | "dark" | "corporate" | "academic" | "tech";
 
 export interface StyleDefinition {
-  name: StyleName;
+  name: string;
   description: string;
   compatibleThemes: ThemeName[];
   css: string;

--- a/src/tools/list_themes_and_styles.ts
+++ b/src/tools/list_themes_and_styles.ts
@@ -6,7 +6,12 @@
 
 import { z } from "zod";
 import { getAvailableThemeNames, getTheme, getActiveTheme } from "../themes/index.js";
-import { getAvailableStyleNames, getStyle, getActiveStyle } from "../styles/index.js";
+import {
+  getAvailableStyleNames,
+  getStyle,
+  getActiveStyle,
+  getExternalStyles,
+} from "../styles/index.js";
 import type { ToolResponse } from "../types/common.js";
 
 export const listThemesAndStylesSchema = z.object({});
@@ -30,8 +35,12 @@ export async function listThemesAndStyles(): Promise<ToolResponse> {
     };
   });
 
+  const externalNames = new Set(
+    getExternalStyles().map((entry) => entry.def.name)
+  );
+
   const styles = styleNames
-    .filter((name) => name !== "default")
+    .filter((name) => name !== "default" && !externalNames.has(name))
     .map((name) => {
       const style = getStyle(name)!;
       return {
@@ -45,6 +54,17 @@ export async function listThemesAndStyles(): Promise<ToolResponse> {
         layouts: Object.keys(style.layouts),
       };
     });
+
+  const externalStyles = getExternalStyles().map(({ def, source }) => ({
+    name: def.name,
+    description: def.description,
+    compatibleThemes:
+      def.compatibleThemes.length > 0 ? def.compatibleThemes : ["all themes"],
+    layoutCount: Object.keys(def.layouts).length,
+    layouts: Object.keys(def.layouts),
+    source,
+    external: true as const,
+  }));
 
   return {
     content: [
@@ -65,7 +85,7 @@ export async function listThemesAndStyles(): Promise<ToolResponse> {
                 "Styles add layouts on top of themes. Use list_layouts to see the merged layout list for a specific theme+style combination.",
             },
             themes,
-            styles,
+            styles: [...styles, ...externalStyles],
           },
           null,
           2

--- a/src/utils/__tests__/external-styles.test.ts
+++ b/src/utils/__tests__/external-styles.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { promises as fs } from "fs";
+import { mkdtemp, rm, writeFile, mkdir } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { discoverExternalStyles } from "../external-styles.js";
+import {
+  clearExternalStyles,
+  getAvailableStyleNames,
+  getExternalStyles,
+  getStyle,
+} from "../../styles/index.js";
+
+async function makeTempDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "marp-mcp-external-"));
+}
+
+describe("discoverExternalStyles", () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    clearExternalStyles();
+    cwd = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    clearExternalStyles();
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it("registers a single style from a string themeSet", async () => {
+    await writeFile(join(cwd, "sample.css"), "/* @theme sample */\nsection { background: #fff; }\n");
+    await writeFile(join(cwd, ".marprc.yml"), "themeSet: ./sample.css\n");
+
+    const result = await discoverExternalStyles(cwd);
+
+    expect(result.registered).toEqual(["sample"]);
+    expect(getStyle("sample")).toBeDefined();
+    expect(getAvailableStyleNames()).toContain("sample");
+    expect(getExternalStyles()).toHaveLength(1);
+    expect(getExternalStyles()[0].source).toBe(join(cwd, "sample.css"));
+  });
+
+  it("registers every entry from an array themeSet", async () => {
+    await writeFile(join(cwd, "a.css"), "/* @theme alpha */\n");
+    await writeFile(join(cwd, "b.css"), "/* @theme beta */\n");
+    await writeFile(
+      join(cwd, ".marprc.yml"),
+      "themeSet:\n  - ./a.css\n  - ./b.css\n"
+    );
+
+    const result = await discoverExternalStyles(cwd);
+
+    expect(result.registered.sort()).toEqual(["alpha", "beta"]);
+  });
+
+  it("expands a directory themeSet to its top-level CSS files only", async () => {
+    const themesDir = join(cwd, "themes");
+    await mkdir(themesDir);
+    await mkdir(join(themesDir, "nested"));
+    await writeFile(join(themesDir, "top.css"), "/* @theme top */\n");
+    await writeFile(join(themesDir, "nested", "deep.css"), "/* @theme deep */\n");
+    await writeFile(join(cwd, ".marprc.yml"), "themeSet: ./themes\n");
+
+    const result = await discoverExternalStyles(cwd);
+
+    expect(result.registered).toEqual(["top"]);
+    expect(getStyle("deep")).toBeUndefined();
+  });
+
+  it("skips CSS files without an @theme directive", async () => {
+    await writeFile(join(cwd, "no-theme.css"), "section { color: red; }\n");
+    await writeFile(join(cwd, ".marprc.yml"), "themeSet: ./no-theme.css\n");
+
+    const result = await discoverExternalStyles(cwd);
+
+    expect(result.registered).toEqual([]);
+  });
+
+  it("skips paths that do not exist", async () => {
+    await writeFile(join(cwd, ".marprc.yml"), "themeSet: ./missing.css\n");
+
+    const result = await discoverExternalStyles(cwd);
+
+    expect(result.registered).toEqual([]);
+  });
+
+  it("returns an empty result for malformed YAML configuration", async () => {
+    await writeFile(join(cwd, ".marprc.yml"), ":\n  - this is : not: valid: yaml: [\n");
+
+    const result = await discoverExternalStyles(cwd);
+
+    expect(result.registered).toEqual([]);
+    expect(result.configPath).toBeNull();
+  });
+
+  it("returns an empty result when no config is found", async () => {
+    const result = await discoverExternalStyles(cwd);
+    expect(result).toEqual({ registered: [], configPath: null });
+  });
+
+  it("lowercases the registered name so CLI -s matches", async () => {
+    await writeFile(join(cwd, "mixed.css"), "/* @theme MixedCase */\n");
+    await writeFile(join(cwd, ".marprc.yml"), "themeSet: ./mixed.css\n");
+
+    await discoverExternalStyles(cwd);
+
+    expect(getStyle("mixedcase")).toBeDefined();
+    expect(getStyle("MixedCase")).toBeUndefined();
+  });
+});

--- a/src/utils/external-styles.ts
+++ b/src/utils/external-styles.ts
@@ -1,0 +1,168 @@
+/**
+ * Discover external Marp styles from a marp-cli compatible configuration.
+ *
+ * marp-cli resolves its configuration via cosmiconfig under module name
+ * `marp` (see https://github.com/marp-team/marp-cli/blob/main/docs/configuration.md).
+ * We reuse the same mechanism so any CSS theme listed under the resolved
+ * config's `themeSet` field is registered as a runtime MCP style.
+ *
+ * Each CSS file's `/* @theme NAME *​/` directive (matched with the same
+ * regex Marpit uses) becomes the style name. External styles inherit the
+ * default style's (empty) layout map so all existing tools keep working
+ * — layouts continue to come from the active theme.
+ *
+ * Every IO/parse error is caught and logged; discovery must never throw.
+ */
+
+import { promises as fs } from "fs";
+import { dirname, extname, isAbsolute, resolve } from "path";
+import { cosmiconfig } from "cosmiconfig";
+import { registerExternalStyle } from "../styles/index.js";
+import { warn, info } from "./logger.js";
+import type { StyleDefinition } from "../themes/types.js";
+
+const MODULE_NAME = "marp";
+
+// Marpit's @theme directive regex, matching marp-team/marpit's theme parser.
+const THEME_DIRECTIVE = /\/\*[\s\S]*?@theme\s+([^\s*]+)[\s\S]*?\*\//;
+
+interface DiscoveryResult {
+  registered: string[];
+  configPath: string | null;
+}
+
+export async function discoverExternalStyles(
+  cwd: string = process.cwd()
+): Promise<DiscoveryResult> {
+  const result: DiscoveryResult = { registered: [], configPath: null };
+
+  let configResult: { config: unknown; filepath: string } | null = null;
+  try {
+    const explorer = cosmiconfig(MODULE_NAME);
+    configResult = await explorer.search(cwd);
+  } catch (err) {
+    warn("Failed to load marp configuration; skipping external styles", {
+      cwd,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return result;
+  }
+
+  if (!configResult) return result;
+  result.configPath = configResult.filepath;
+
+  const themeSet = extractThemeSet(configResult.config);
+  if (themeSet.length === 0) return result;
+
+  const baseDir = dirname(configResult.filepath);
+  const cssPaths = await collectCssPaths(themeSet, baseDir);
+
+  for (const cssPath of cssPaths) {
+    const def = await loadStyleFromCss(cssPath);
+    if (!def) continue;
+    if (registerExternalStyle(def, cssPath)) {
+      result.registered.push(def.name);
+    }
+  }
+
+  if (result.registered.length > 0) {
+    info("Registered external Marp styles from themeSet", {
+      configPath: configResult.filepath,
+      styles: result.registered,
+    });
+  }
+
+  return result;
+}
+
+function extractThemeSet(config: unknown): string[] {
+  if (!config || typeof config !== "object") return [];
+  const value = (config as Record<string, unknown>).themeSet;
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === "string");
+  }
+  return [];
+}
+
+async function collectCssPaths(
+  themeSet: string[],
+  baseDir: string
+): Promise<string[]> {
+  const out: string[] = [];
+
+  for (const entry of themeSet) {
+    const absolute = isAbsolute(entry) ? entry : resolve(baseDir, entry);
+    let stat;
+    try {
+      stat = await fs.stat(absolute);
+    } catch (err) {
+      warn("themeSet entry does not exist on disk; skipping", {
+        path: absolute,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      try {
+        const entries = await fs.readdir(absolute);
+        for (const name of entries) {
+          if (extname(name).toLowerCase() === ".css") {
+            out.push(resolve(absolute, name));
+          }
+        }
+      } catch (err) {
+        warn("Failed to read themeSet directory; skipping", {
+          path: absolute,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    } else if (stat.isFile()) {
+      if (extname(absolute).toLowerCase() === ".css") {
+        out.push(absolute);
+      } else {
+        warn("themeSet entry is not a .css file; skipping", { path: absolute });
+      }
+    }
+  }
+
+  return out;
+}
+
+async function loadStyleFromCss(
+  cssPath: string
+): Promise<StyleDefinition | null> {
+  let css: string;
+  try {
+    css = await fs.readFile(cssPath, "utf-8");
+  } catch (err) {
+    warn("Failed to read external style CSS; skipping", {
+      path: cssPath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+
+  const match = css.match(THEME_DIRECTIVE);
+  if (!match) {
+    warn(
+      "CSS file does not declare a /* @theme NAME */ directive; skipping",
+      { path: cssPath }
+    );
+    return null;
+  }
+
+  // Normalise to lowercase so CLI input (which lowercases `-s <name>`)
+  // can match external names regardless of the casing used in the @theme
+  // directive.
+  const name = match[1].toLowerCase();
+
+  return {
+    name,
+    description: `External style discovered from ${cssPath}`,
+    compatibleThemes: [],
+    css,
+    layouts: {},
+  };
+}


### PR DESCRIPTION
## Summary

- marp-mcp now reads the same configuration files marp-cli already resolves (`.marprc.*`, `marp.config.*`, `package.json` `marp` field) via cosmiconfig and registers any CSS theme listed under `themeSet` as an MCP style at server start.
- Each CSS file contributes its `/* @theme NAME */` directive as the style name (lowercased so `-s <name>` matches regardless of directive casing) and reuses the active theme's layout set, so `list_layouts`, `manage_slide`, `set_frontmatter`, `create_presentation`, and `batch_manage_slides` work without further code changes.
- Built-in style names remain protected. External collisions are skipped with a stderr warning; external-vs-external collisions take the last registration and warn once.
- The public `StyleName` union is unchanged. The runtime registry splits into a built-in record and an external `Map`; lookups consult externals first, then built-ins. Public signatures accept `string` and `StyleDefinition.name` is widened to `string` so external names are first-class without a breaking union change.

## Motivation

Today the styles registry is a closed union. Anyone who wants their own visual style has to fork the package, even though marp-cli already resolves theme CSS via `themeSet`. Reusing that mechanism gives one source of truth across marp-cli and marp-mcp.

## Behaviour

- No new flags. Discovery happens once before `program.parseAsync()` so external names are valid arguments for `-s` and appear in the registry surfaced to MCP tools.
- Missing files, unreadable files, CSS without `@theme`, and malformed configs are logged to stderr through the existing structured logger and skipped — never fatal.
- `list_themes_and_styles` includes each discovered style with its `name`, `description`, layout count, absolute `source` path, and `external: true`.

## Tests

New suites under `src/utils/__tests__/external-styles.test.ts` and `src/styles/__tests__/external-style.test.ts` cover:

- `.marprc.yml` with string `themeSet`, array `themeSet`, and directory `themeSet` (top-level `*.css` only).
- CSS without `@theme`, missing on-disk paths, malformed YAML, and missing config — all return an empty result without throwing.
- `@theme NAME` case-folding so the CLI `-s` flag matches.
- Built-in collision rejection, external overwrite-and-warn, and `setActiveStyle` activating an external entry.

`pnpm test` passes the new suites along with the existing 117 tests. The two `export_slide` HTML failures observed locally are present on `main` (independent of this change). `pnpm run build` and `npx tsc --noEmit` are both clean.

## Notes

- `cosmiconfig` is added as a runtime dependency — the same library marp-cli uses for its own config discovery, so behaviour matches by construction.
- `defaultStyle.layouts` is `{}`, so external entries currently add CSS only; layout templates continue to come from the active theme. This keeps the integration intentionally narrow and avoids requiring external authors to ship layout templates.
- README is generated from `src/__tests__/readme-generator.test.ts`; documentation for the new mechanism was added there so `pnpm test` keeps the README in sync.